### PR TITLE
Fix github links

### DIFF
--- a/custom_components/xiaomi_airfryer/manifest.json
+++ b/custom_components/xiaomi_airfryer/manifest.json
@@ -4,8 +4,8 @@
   "version": "0.0.1",
   "iot_class": "local_polling",
   "config_flow": true,
-  "documentation": "https://github.com/tsunglung/xiaomi_airfryer",
-  "issue_tracker": "https://github.com/tsunglung/xiaomi_airfryer/issues",
+  "documentation": "https://github.com/tsunglung/XiaomiAirFryer",
+  "issue_tracker": "https://github.com/tsunglung/XiaomiAirFryer/issues",
   "requirements": [
     "construct==2.10.56",
     "micloud==0.4",


### PR DESCRIPTION
When you go to Settings->Integrations->Mi Air Fryer and click on Documentation or Known issues in the Menu, the links are broken.