### PR TITLE
Add support for Xiaomi Smart Air Fryer 4.5L Global

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 | Silencare AirFryer 1.8L     | silen.fryer.sck501  |   |
 | Silencare AirFryer          | silen.fryer.sck505  | |
 | Viomi Smart Air Fryer Pro 6L| viomi.fryer.v3      | |
+| Xiaomi Smart Air Fryer 4.5L| xiaomi.fryer.maf14      | |
 
 ## Features
 

--- a/custom_components/xiaomi_airfryer/__init__.py
+++ b/custom_components/xiaomi_airfryer/__init__.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 
 from miio import DeviceException
-from .fryer_miot import FryerMiot, FryerMiotYBAF, FryerMiotSCK, FryerMiotMi, FryerMiotViomi
+from .fryer_miot import FryerMiot, FryerMiotYBAF, FryerMiotSCK, FryerMiotMi, FryerMiotViomi, FryerMiotXiaomi
 
 from .const import (
     ATTR_MODE,
@@ -43,6 +43,7 @@ from .const import (
     MODELS_SILEN,
     MODELS_MIOT,
     MODELS_VIOMI,
+    MODELS_XIAOMI,
     MODELS_ALL_DEVICES
 )
 
@@ -106,6 +107,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         fryer = FryerMiotMi(host, token, model=model)
     elif model in MODELS_VIOMI:
         fryer = FryerMiotViomi(host, token, model=model)
+    elif model in MODELS_XIAOMI:
+        fryer = FryerMiotXiaomi(host, token, model=model)
     elif model in MODELS_ALL_DEVICES:
         fryer = FryerMiot(host, token, model=model)
     hass.data[DOMAIN][host] = fryer

--- a/custom_components/xiaomi_airfryer/const.py
+++ b/custom_components/xiaomi_airfryer/const.py
@@ -22,6 +22,7 @@ MODEL_FRYER_SCK501 = "silen.fryer.sck501"
 MODEL_FRYER_SCK505 = "silen.fryer.sck505"
 MODEL_FRYER_534 = "miot.fryer.534"
 MODEL_FRYER_V3 = "viomi.fryer.v3"
+MODEL_FRYER_MAF14 = "xiaomi.fryer.maf14"
 
 OPT_MODEL = {
     MODEL_FRYER_MAF01: "Mi Smart Air Fryer China",
@@ -34,6 +35,7 @@ OPT_MODEL = {
     MODEL_FRYER_SCK501: "Silencare AirFryer 1.8L",
     MODEL_FRYER_SCK505: "Silencare AirFryer",
     MODEL_FRYER_V3: "Viomi Smart Air Fryer Pro 6L",
+    MODEL_FRYER_MAF14: "Xiaomi Smart Air Fryer 4.5L Global",
 }
 
 MODELS_CARELI = [
@@ -55,7 +57,10 @@ MODELS_MIOT = [
 MODELS_VIOMI = [
     MODEL_FRYER_V3
 ]
-MODELS_ALL_DEVICES = MODELS_CARELI + MODELS_SILEN + MODELS_MIOT + MODELS_VIOMI
+MODELS_XIAOMI = [
+    MODEL_FRYER_MAF14
+]
+MODELS_ALL_DEVICES = MODELS_CARELI + MODELS_SILEN + MODELS_MIOT + MODELS_VIOMI + MODELS_XIAOMI
 
 ATTR_FOOD_QUANTY = "food_quanty"
 ATTR_MODEL = "model"

--- a/custom_components/xiaomi_airfryer/sensor.py
+++ b/custom_components/xiaomi_airfryer/sensor.py
@@ -32,6 +32,7 @@ from .const import (
     MODELS_MIOT,
     MODELS_SILEN,
     MODELS_VIOMI,
+    MODELS_XIAOMI,
     MODELS_ALL_DEVICES
 )
 
@@ -88,6 +89,15 @@ SENSOR_TYPES_VIOMI = {
     "turn_pot_status": ["Turn Pot Status", None, "turn_pot_status", None, "mdi:rotate-3d-variant", None],
 }
 
+SENSOR_TYPES_XIAOMI = {
+    "status": ["Status", None, "status", None, "mdi:bowl", None],
+    "mode": ["Mode", None, "mode", None, "mdi:stairs", None],
+    "target_time": ["Target Time", None, "target_time", UnitOfTime.MINUTES, "mdi:menu", None],
+    "left_time": ["Remaining", None, "left_time", UnitOfTime.MINUTES, "mdi:timer", None],
+    "target_temperature": ["Target Temperature", None, "target_temperature", UnitOfTemperature.CELSIUS, None,SensorDeviceClass.TEMPERATURE],
+    "recipe_id": ["Recipe Id", None, "recipe_id", None, "mdi:rice", None],
+    "turn_pot": ["Turn Pot", None, "turn_pot", None, "mdi:rotate-3d-variant", None],
+}
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Import Mijia AirFryer configuration from YAML."""
@@ -150,6 +160,9 @@ async def async_setup_entry(hass, config, async_add_devices, discovery_info=None
             sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
     elif model in MODELS_VIOMI:
         for stype in SENSOR_TYPES_VIOMI.values():
+            sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
+    elif model in MODELS_XIAOMI:
+        for stype in SENSOR_TYPES_XIAOMI.values():
             sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
     elif model in MODELS_ALL_DEVICES:
         for stype in SENSOR_TYPES_YBAF.values():


### PR DESCRIPTION
Hello! This PR adds support for the global version of the air fryer.

Discovered endpoints through [miot-spec](https://home.miot-spec.com/spec/xiaomi.fryer.maf14), tested on my device. It's a bit off with recipe names, can't tackle it down yet, but manual mode with custom temp and time works fine.

Also reworked statuses a bit: removed the overrides and added direct status mappings.

<details><summary>Home Assistant screenshots</summary>

![image](https://github.com/user-attachments/assets/8ff3e920-2827-474a-9bc5-b7a3e7acf61f)
![image](https://github.com/user-attachments/assets/c78d18ec-670e-4a7d-9ff8-77092106b3a6)

</details>