### PR TITLE
fix: initialize host data for each config entry

### DIFF
--- a/custom_components/xiaomi_airfryer/__init__.py
+++ b/custom_components/xiaomi_airfryer/__init__.py
@@ -91,9 +91,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         model = entry.options.get(CONF_MODEL)
         scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
-    if DATA_KEY not in hass.data:
-        hass.data.setdefault(DATA_KEY, {})
-        hass.data[DATA_KEY][host] = {}
+    hass.data.setdefault(DATA_KEY, {})
+    hass.data[DATA_KEY].setdefault(host, {})
 
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}


### PR DESCRIPTION
Fixes setup for multiple air fryer entries by always initializing the per host data cache.