### PR TITLE
fix(maf10a): apply per model MIOT mapping, add missing sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 
 ## Supported devices
 
-| Name                        | Model                  | Model no. |
-|  -------------------------  | ---------------------- | --------- |
-|                             | careli.fryer.maf01  |   |
-| Mi Smart Air Fryer          | careli.fryer.maf02  |   |
-|                             | careli.fryer.maf03  | |
-|                             | careli.fryer.maf05a  | |
-|                             | careli.fryer.maf10a  | |
-|                             | careli.fryer.maf07  | |
-| Upany Air Fryer YB-02208DTW | careli.fryer.ybaf01 | |
-| Silencare AirFryer 1.8L     | silen.fryer.sck501  |   |
-| Silencare AirFryer          | silen.fryer.sck505  | |
-| Viomi Smart Air Fryer Pro 6L| viomi.fryer.v3      | |
-| Xiaomi Smart Air Fryer 4.5L| xiaomi.fryer.maf14      | |
+| Name                         | Model                  | Model no. |
+|------------------------------| ---------------------- | --------- |
+|                              | careli.fryer.maf01  |   |
+| Mi Smart Air Fryer           | careli.fryer.maf02  |   |
+|                              | careli.fryer.maf03  | |
+|                              | careli.fryer.maf05a  | |
+| Xiaomi Smart Air Fryer 6.5L  | careli.fryer.maf10a  | |
+|                              | careli.fryer.maf07  | |
+| Upany Air Fryer YB-02208DTW  | careli.fryer.ybaf01 | |
+| Silencare AirFryer 1.8L      | silen.fryer.sck501  |   |
+| Silencare AirFryer           | silen.fryer.sck505  | |
+| Viomi Smart Air Fryer Pro 6L | viomi.fryer.v3      | |
+| Xiaomi Smart Air Fryer 4.5L  | xiaomi.fryer.maf14      | |
 
 ## Features
 

--- a/custom_components/xiaomi_airfryer/fryer_miot.py
+++ b/custom_components/xiaomi_airfryer/fryer_miot.py
@@ -126,8 +126,8 @@ MIOT_MAPPING = {
         "recipe_sync": {"siid": 2, "piid": 12},  # read, notify, write
         "taret_cooking_measure": {"siid": 2, "piid": 13},  # read, notify, write
         "turn_pot": {"siid": 2, "piid": 14},  # read, notify
-        "turn_pot_config": {"siid": 2, "piid": 15},  # read, notify, write   <-- FIXED (ήταν 16)
-        "texture": {"siid": 2, "piid": 16},  # read, notify, write          <-- NEW
+        "turn_pot_config": {"siid": 2, "piid": 15},  # read, notify, write
+        "texture": {"siid": 2, "piid": 16},  # read, notify, write
         "reservation_left_time": {"siid": 2, "piid": 17},  # read, notify, write
         "cooking_weight": {"siid": 2, "piid": 18},  # read, notify, write
         "start_cook": {"siid": 2, "aiid": 1},

--- a/custom_components/xiaomi_airfryer/fryer_miot.py
+++ b/custom_components/xiaomi_airfryer/fryer_miot.py
@@ -110,6 +110,7 @@ MIOT_MAPPING = {
         "start_custom_cook": {"siid": 3, "aiid": 1},
         "resume_cooking": {"siid": 3, "aiid": 2}
     },
+    # http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-fryer:0000A0A4:careli-maf10a:1
     MODEL_FRYER_MAF10A: {
         "status": {"siid": 2, "piid": 1},  # read, notify
         "device_fault": {"siid": 2, "piid": 2},  # read, notify
@@ -125,7 +126,8 @@ MIOT_MAPPING = {
         "recipe_sync": {"siid": 2, "piid": 12},  # read, notify, write
         "taret_cooking_measure": {"siid": 2, "piid": 13},  # read, notify, write
         "turn_pot": {"siid": 2, "piid": 14},  # read, notify
-        "turn_pot_config": {"siid": 2, "piid": 16},  # read, notify, write
+        "turn_pot_config": {"siid": 2, "piid": 15},  # read, notify, write   <-- FIXED (ήταν 16)
+        "texture": {"siid": 2, "piid": 16},  # read, notify, write          <-- NEW
         "reservation_left_time": {"siid": 2, "piid": 17},  # read, notify, write
         "cooking_weight": {"siid": 2, "piid": 18},  # read, notify, write
         "start_cook": {"siid": 2, "aiid": 1},
@@ -359,6 +361,7 @@ class CookingModeXiaomi(enum.Enum):
 
 
 class CookingTexture(enum.Enum):
+    Unknown = -1
     NONE = 0
     CrispyRoast = 1
     TenderRoast = 2
@@ -506,6 +509,34 @@ class FryerStatusMiot(DeviceStatus):
             _LOGGER.error("Unknown TurnPot (%s)", self.data["turn_pot"])
             return TurnPot.Unknown
 
+    @property
+    def preheat(self) -> bool:
+        """Preheat phase."""
+        return self.data["preheat"]
+
+    @property
+    def turn_pot_config(self) -> bool:
+        """Turn Pot Config."""
+        return self.data["turn_pot_config"]
+
+    @property
+    def texture(self) -> CookingTexture:
+        """Texture."""
+        try:
+            return CookingTexture(self.data["texture"])
+        except ValueError:
+            _LOGGER.error("Unknown Texture (%s)", self.data["texture"])
+            return CookingTexture.Unknown
+
+    @property
+    def reservation_left_time(self) -> int:
+        """Reservation Left Time."""
+        return self.data["reservation_left_time"]
+
+    @property
+    def cooking_weight(self) -> int:
+        """Cooking Weight."""
+        return self.data["cooking_weight"]
 
 class FryerMiot(MiotDevice):
     """Interface for AirFryer (careli.fryer.maf02)"""
@@ -525,6 +556,7 @@ class FryerMiot(MiotDevice):
 
         super().__init__(ip, token, start_id, debug, lazy_discover)
         self._model = model
+        self.mapping = MIOT_MAPPING[model]
 
     @command(
         default_output=format_output(

--- a/custom_components/xiaomi_airfryer/sensor.py
+++ b/custom_components/xiaomi_airfryer/sensor.py
@@ -28,6 +28,7 @@ from .const import (
     DATA_STATE,
     DOMAIN,
     MODEL_FRYER_YBAF01,
+    MODEL_FRYER_MAF10A,
     MODELS_CARELI,
     MODELS_MIOT,
     MODELS_SILEN,
@@ -99,6 +100,21 @@ SENSOR_TYPES_XIAOMI = {
     "turn_pot": ["Turn Pot", None, "turn_pot", None, "mdi:rotate-3d-variant", None],
 }
 
+SENSOR_TYPES_MAF10A = {
+    "status": ["Status", None, "status", None, "mdi:bowl", None],
+    "mode": ["Mode", None, "mode", None, "mdi:stairs", None],
+    "target_time": ["Target Time", None, "target_time", UnitOfTime.MINUTES, "mdi:menu", None],
+    "left_time": ["Remaining", None, "left_time", UnitOfTime.MINUTES, "mdi:timer", None],
+    "target_temperature": ["Target Temperature", None, "target_temperature", UnitOfTemperature.CELSIUS, None, SensorDeviceClass.TEMPERATURE],
+    "recipe_id": ["Recipe Id", None, "recipe_id", None, "mdi:rice", None],
+    "preheat": ["Preheat Phase", None, "preheat", None, "mdi:pot-steam-outline", None],
+    "turn_pot": ["Turn Pot", None, "turn_pot", None, "mdi:rotate-3d-variant", None],
+    "turn_pot_config": ["Turn Pot Config", None, "turn_pot_config", None, "mdi:rotate-3d-variant", None],
+    "texture": ["Texture", None, "texture", None, "mdi:pot-steam", None],
+    "reservation_left_time": ["Reservation Left Time", None, "reservation_left_time", UnitOfTime.MINUTES, "mdi:timer", None],
+    "cooking_weight": ["Cooking Weight", None, "cooking_weight", None, "mdi:scale", None],
+}
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Import Mijia AirFryer configuration from YAML."""
     _LOGGER.warning(
@@ -149,6 +165,9 @@ async def async_setup_entry(hass, config, async_add_devices, discovery_info=None
     if model == MODEL_FRYER_YBAF01:
         for stype in SENSOR_TYPES_YBAF.values():
             sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
+    elif model == MODEL_FRYER_MAF10A:
+        for stype in SENSOR_TYPES_MAF10A.values():
+            sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
     elif model in MODELS_CARELI:
         for stype in SENSOR_TYPES_MAF.values():
             sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
@@ -163,9 +182,6 @@ async def async_setup_entry(hass, config, async_add_devices, discovery_info=None
             sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
     elif model in MODELS_XIAOMI:
         for stype in SENSOR_TYPES_XIAOMI.values():
-            sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
-    elif model in MODELS_ALL_DEVICES:
-        for stype in SENSOR_TYPES_YBAF.values():
             sensors.append(XiaomiAirFryerSensor(fryer, host, stype, config))
     else:
         _LOGGER.error(

--- a/custom_components/xiaomi_airfryer/switch.py
+++ b/custom_components/xiaomi_airfryer/switch.py
@@ -42,6 +42,7 @@ from .const import (
     DATA_KEY,
     DEFAULT_NAME,
     DOMAIN,
+    MODEL_FRYER_MAF10A,
     MODELS_CARELI,
     MODELS_ALL_DEVICES,
     SERVICE_APPOINT_TIME,
@@ -324,6 +325,13 @@ class XiaomiAirFryer(SwitchEntity):
 
     async def async_start_custom(self, mode: str):
         """Start custom cooking."""
+        if self._model == MODEL_FRYER_MAF10A:
+            _LOGGER.warning(
+                "start_custom is not supported on %s (no start_custom_cook action)",
+                self._model,
+            )
+            return
+
         if self._model in MODELS_CARELI:
             mode_value = MODE_MAF[mode]
         else:


### PR DESCRIPTION
FryerMiot never applied the model-specific mapping (used MAF02's by default), so MAF10A queried wrong properties. Adds the fix + the sensors that now actually work (mode, preheat, turn_pot_config, texture, reservation_left_time, cooking_weight).